### PR TITLE
add event stream

### DIFF
--- a/tap_gorgias/schemas/events.json
+++ b/tap_gorgias/schemas/events.json
@@ -1,0 +1,40 @@
+{
+    "type": [
+      "object"
+    ],
+    "properties": {
+        "id": {
+            "type": ["int", "null"],
+            "description": "The id of the event."
+        },
+        "context": {
+            "type": ["string", "null"],
+            "description": "hash id."
+        },
+        "created_datetime": {
+            "type": ["string"],
+            "description": "The time the event was created",
+            "format": "date-time"
+        },
+        "data": {
+            "type": ["object", "null"],
+            "description": "The data associated with the event."
+        },
+        "object_id": {
+            "type": ["int", "null"],
+            "description": "The event object id"
+        },
+        "object_type": {
+            "type": ["string", "null"],
+            "description": "The type of object assocaited with the event"
+        },
+        "type": {
+            "type": ["string", "null"],
+            "description": "The type of event"
+        },
+        "user_id": {
+            "type": ["int", "null"],
+            "description": "ID of the user associated with the event"
+        }
+    }
+}

--- a/tap_gorgias/tap.py
+++ b/tap_gorgias/tap.py
@@ -12,6 +12,7 @@ from tap_gorgias.streams import (
     CustomersStream,
     TicketDetailsStream,
     IntegreationsStream,
+    EventStream
 )
 
 STREAM_TYPES = [
@@ -21,6 +22,7 @@ STREAM_TYPES = [
     CustomersStream,
     TicketDetailsStream,
     IntegreationsStream,
+    EventStream,
 ]
 
 


### PR DESCRIPTION
- added event stream to tap-gorgias
- the created_datetime field type is set to string and format of date-time because the DatetimeType is singer_sdk inherits from the StringType and the partition_key logic validates timestamp/datetime types by accessing the value of the `format` key in the DatetimeType type_dict.